### PR TITLE
Added LOG_PREAMBLE for custom log preamble strings

### DIFF
--- a/DebugLog.h
+++ b/DebugLog.h
@@ -28,7 +28,6 @@ using DebugLogPrecision = arx::debug::LogPrecision;
 #define LOG_AS_ARR(arr, sz) DebugLog::to_arr(arr, sz)
 #define LOG_GET_LEVEL() DebugLog::Manager::get().log_level()
 #define LOG_SET_LEVEL(l) DebugLog::Manager::get().log_level(l)
-#define LOG_SET_OPTION(file, line, func) DebugLog::Manager::get().option(file, line, func)
 #define LOG_SET_DELIMITER(d) DebugLog::Manager::get().delimiter(d)
 #define LOG_SET_BASE_RESET(b) DebugLog::Manager::get().base_reset(b)
 

--- a/DebugLog/Manager.h
+++ b/DebugLog/Manager.h
@@ -118,7 +118,7 @@ namespace debug {
 #endif  // ARDUINO
 
         template <typename... Args>
-        void log(const LogLevel level, const char* file, const int line, const char* func, Args&&... args) {
+        void log(const LogLevel level, Args&&... args) {
             bool b_ignore = (log_lvl == LogLevel::LVL_NONE);
 #ifdef ARDUINO
             b_ignore &= (file_lvl == LogLevel::LVL_NONE);
@@ -126,7 +126,7 @@ namespace debug {
             b_ignore |= (level == LogLevel::LVL_NONE);
             if (b_ignore) return;
 
-            string_t header = generate_header(level, file, line, func);
+            string_t header = generate_header(level);
             if ((int)level <= (int)log_lvl) {
                 print(header);  // to avoid delimiter after header
                 println(std::forward<Args>(args)...);
@@ -391,7 +391,7 @@ namespace debug {
 
         // ===== other utilities =====
 
-        string_t generate_header(const LogLevel lvl, const char* file, const int line, const char* func) const {
+        string_t generate_header(const LogLevel lvl) const {
             string_t header;
             switch (lvl) {
                 case LogLevel::LVL_ERROR: header = "[ERROR] "; break;
@@ -401,27 +401,6 @@ namespace debug {
                 case LogLevel::LVL_TRACE: header = "[TRACE] "; break;
                 default: header = ""; break;
             }
-#ifdef ARDUINO
-            if (b_file) header += file + string_t(" ");
-            if (b_line) header += string_t("L.") + line + string_t(" ");
-            if (b_func) header += func + string_t(" ");
-            header += string_t(": ");
-#else
-            if (b_file) {
-                header += file;
-                header += " ";
-            };
-            if (b_line) {
-                header += "L.";
-                header += std::to_string(line);
-                header += " ";
-            }
-            if (b_func) {
-                header += func;
-                header += " ";
-            };
-            header += ": ";
-#endif
             return header;
         }
     };

--- a/DebugLog/Manager.h
+++ b/DebugLog/Manager.h
@@ -12,9 +12,6 @@ namespace debug {
         LogLevel log_lvl {DEBUGLOG_DEFAULT_LOG_LEVEL};
         LogBase log_base {LogBase::DEC};
         string_t delim {" "};
-        bool b_file {true};
-        bool b_line {true};
-        bool b_func {true};
         bool b_base_reset {true};
 
 #ifdef ARDUINO
@@ -42,12 +39,6 @@ namespace debug {
 
         void log_level(const LogLevel l) {
             log_lvl = l;
-        }
-
-        void option(const bool en_file, const bool en_line, const bool en_func) {
-            b_file = en_file;
-            b_line = en_line;
-            b_func = en_func;
         }
 
         void delimiter(const string_t& del) {

--- a/DebugLogEnable.h
+++ b/DebugLogEnable.h
@@ -6,11 +6,16 @@
 #undef ASSERT
 #undef ASSERTM
 
+#define LOG_SHORT_FILENAME (strrchr(__FILE__, '/') ? strrchr(__FILE__, '/') + 1 : strrchr(__FILE__, '\\') ? strrchr(__FILE__, '\\') + 1 : __FILE__)
+
+// C pre-proc Token Concatenation: https://wiki.sei.cmu.edu/confluence/display/c/PRE05-C.+Understand+macro+replacement+when+concatenating+tokens+or+performing+stringification
+#define xstr(s) str(s)
+#define str(s) #s
+
 #ifndef LOG_PREAMBLE
-  #define LOG_PREAMBLE LOG_SHORT_FILENAME, __LINE__, __func__
+  #define LOG_PREAMBLE LOG_SHORT_FILENAME, xstr(L.__LINE__), __func__, ":"
 #endif
 
-#define LOG_SHORT_FILENAME (strrchr(__FILE__, '/') ? strrchr(__FILE__, '/') + 1 : strrchr(__FILE__, '\\') ? strrchr(__FILE__, '\\') + 1 : __FILE__)
 #define LOG_ERROR(...) DebugLog::Manager::get().log(arx::debug::LogLevel::LVL_ERROR, LOG_PREAMBLE, __VA_ARGS__)
 #define  LOG_WARN(...)  DebugLog::Manager::get().log(arx::debug::LogLevel::LVL_WARN, LOG_PREAMBLE, __VA_ARGS__)
 #define  LOG_INFO(...)  DebugLog::Manager::get().log(arx::debug::LogLevel::LVL_INFO, LOG_PREAMBLE, __VA_ARGS__)

--- a/DebugLogEnable.h
+++ b/DebugLogEnable.h
@@ -6,12 +6,16 @@
 #undef ASSERT
 #undef ASSERTM
 
+#ifndef LOG_PREAMBLE
+  #define LOG_PREAMBLE __LINE__, __func__
+#endif
+
 #define LOG_SHORT_FILENAME (strrchr(__FILE__, '/') ? strrchr(__FILE__, '/') + 1 : strrchr(__FILE__, '\\') ? strrchr(__FILE__, '\\') + 1 : __FILE__)
-#define LOG_ERROR(...) DebugLog::Manager::get().log(arx::debug::LogLevel::LVL_ERROR, LOG_SHORT_FILENAME, __LINE__, __func__, __VA_ARGS__)
-#define LOG_WARN(...) DebugLog::Manager::get().log(arx::debug::LogLevel::LVL_WARN, LOG_SHORT_FILENAME, __LINE__, __func__, __VA_ARGS__)
-#define LOG_INFO(...) DebugLog::Manager::get().log(arx::debug::LogLevel::LVL_INFO, LOG_SHORT_FILENAME, __LINE__, __func__, __VA_ARGS__)
-#define LOG_DEBUG(...) DebugLog::Manager::get().log(arx::debug::LogLevel::LVL_DEBUG, LOG_SHORT_FILENAME, __LINE__, __func__, __VA_ARGS__)
-#define LOG_TRACE(...) DebugLog::Manager::get().log(arx::debug::LogLevel::LVL_TRACE, LOG_SHORT_FILENAME, __LINE__, __func__, __VA_ARGS__)
+#define LOG_ERROR(...) DebugLog::Manager::get().log(arx::debug::LogLevel::LVL_ERROR, LOG_SHORT_FILENAME, LOG_PREAMBLE, __VA_ARGS__)
+#define LOG_WARN(...)  DebugLog::Manager::get().log(arx::debug::LogLevel::LVL_WARN, LOG_SHORT_FILENAME,  LOG_PREAMBLE, __VA_ARGS__)
+#define LOG_INFO(...)  DebugLog::Manager::get().log(arx::debug::LogLevel::LVL_INFO, LOG_SHORT_FILENAME,  LOG_PREAMBLE, __VA_ARGS__)
+#define LOG_DEBUG(...) DebugLog::Manager::get().log(arx::debug::LogLevel::LVL_DEBUG, LOG_SHORT_FILENAME, LOG_PREAMBLE, __VA_ARGS__)
+#define LOG_TRACE(...) DebugLog::Manager::get().log(arx::debug::LogLevel::LVL_TRACE, LOG_SHORT_FILENAME, LOG_PREAMBLE, __VA_ARGS__)
 
 #ifdef ARDUINO
 #define ASSERT(b) DebugLog::Manager::get().assertion((b), LOG_SHORT_FILENAME, __LINE__, __func__, #b)

--- a/DebugLogEnable.h
+++ b/DebugLogEnable.h
@@ -7,15 +7,15 @@
 #undef ASSERTM
 
 #ifndef LOG_PREAMBLE
-  #define LOG_PREAMBLE __LINE__, __func__
+  #define LOG_PREAMBLE LOG_SHORT_FILENAME, __LINE__, __func__
 #endif
 
 #define LOG_SHORT_FILENAME (strrchr(__FILE__, '/') ? strrchr(__FILE__, '/') + 1 : strrchr(__FILE__, '\\') ? strrchr(__FILE__, '\\') + 1 : __FILE__)
-#define LOG_ERROR(...) DebugLog::Manager::get().log(arx::debug::LogLevel::LVL_ERROR, LOG_SHORT_FILENAME, LOG_PREAMBLE, __VA_ARGS__)
-#define LOG_WARN(...)  DebugLog::Manager::get().log(arx::debug::LogLevel::LVL_WARN, LOG_SHORT_FILENAME,  LOG_PREAMBLE, __VA_ARGS__)
-#define LOG_INFO(...)  DebugLog::Manager::get().log(arx::debug::LogLevel::LVL_INFO, LOG_SHORT_FILENAME,  LOG_PREAMBLE, __VA_ARGS__)
-#define LOG_DEBUG(...) DebugLog::Manager::get().log(arx::debug::LogLevel::LVL_DEBUG, LOG_SHORT_FILENAME, LOG_PREAMBLE, __VA_ARGS__)
-#define LOG_TRACE(...) DebugLog::Manager::get().log(arx::debug::LogLevel::LVL_TRACE, LOG_SHORT_FILENAME, LOG_PREAMBLE, __VA_ARGS__)
+#define LOG_ERROR(...) DebugLog::Manager::get().log(arx::debug::LogLevel::LVL_ERROR, LOG_PREAMBLE, __VA_ARGS__)
+#define  LOG_WARN(...)  DebugLog::Manager::get().log(arx::debug::LogLevel::LVL_WARN, LOG_PREAMBLE, __VA_ARGS__)
+#define  LOG_INFO(...)  DebugLog::Manager::get().log(arx::debug::LogLevel::LVL_INFO, LOG_PREAMBLE, __VA_ARGS__)
+#define LOG_DEBUG(...) DebugLog::Manager::get().log(arx::debug::LogLevel::LVL_DEBUG, LOG_PREAMBLE, __VA_ARGS__)
+#define LOG_TRACE(...) DebugLog::Manager::get().log(arx::debug::LogLevel::LVL_TRACE, LOG_PREAMBLE, __VA_ARGS__)
 
 #ifdef ARDUINO
 #define ASSERT(b) DebugLog::Manager::get().assertion((b), LOG_SHORT_FILENAME, __LINE__, __func__, #b)

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Logging library for Arduino that can output to both Serial and File with one lin
 - Multiple file system support (`SD`, `SdFat`, `SPIFFS`, etc.)
 - Support array and container (`std::vector`, `std::deque`, `std::map`) output
 - APIs can also be used in standard C++ apps
+- Log preamble control `#define LOG_PREAMBLE` exposes customization of string that comes before each log message
 
 ## Basic Usage
 
@@ -87,6 +88,34 @@ will output
 [INFO] basic.ino L.28 setup : this is info: log level 3
 [DEBUG] basic.ino L.29 setup : this is debug: log level 4
 [TRACE] basic.ino L.30 setup : this is trace: log level 5
+```
+
+### Log Preamble Control
+The `LOG_PREAMBLE` macro is called every `LOG_XXXX`. It defines a string that will be printed between the `[LEVEL]` and your custom message. To override the default definition, you must define the macro **before** you `#include <DebugLog.h>`
+
+#### Simple LOG_PREAMBLE:
+```C++
+#define LOG_PREAMBLE "||We the People||"
+#include <DebugLog.h>
+
+LOG_ERROR("Message 1");
+LOG_WARN("Message 2");
+LOG_INFO("Message 3");
+```
+
+`Serial` output
+
+```
+[ERROR] ||We the People|| Message 1
+[WARN] ||We the People|| Message 2
+[INFO] ||We the People|| Message 3
+```
+
+#### Default LOG_PREAMBLE:
+The Default `LOG_PREAMBLE` calls other macros and functions. _Note_ the comma separated fields will be space delimeted as they are inputs to the `LOG_XXXX(...)` macro.
+
+```C++
+#define LOG_PREAMBLE LOG_SHORT_FILENAME, xstr(L.__LINE__), __func__, ":"
 ```
 
 ### Assertion

--- a/README.md
+++ b/README.md
@@ -13,7 +13,6 @@ Logging library for Arduino that can output to both Serial and File with one lin
 - Multiple file system support (`SD`, `SdFat`, `SPIFFS`, etc.)
 - Support array and container (`std::vector`, `std::deque`, `std::map`) output
 - APIs can also be used in standard C++ apps
-- Custom preamble support `#define LOG_PREAMBLE` can easily call functions and other macros for every `LOG_XXXXX` call
 
 ## Basic Usage
 
@@ -33,7 +32,6 @@ Logging library for Arduino that can output to both Serial and File with one lin
 `LOG_XXXX` output is controlled by log level. Default log level is `DebugLogLevel::LVL_INFO`
 
 ```C++
-#define LOG_PREAMBLE __FILE__ " : "
 #include <DebugLog.h>
 
 // The default log_leval is DebugLogLevel::LVL_INFO
@@ -47,9 +45,9 @@ LOG_TRACE("this is trace: log level", 5);  // won't be printed
 `Serial` output example
 
 ```
-[ERROR] basic.ino : this is error: log level 1
-[WARN] basic.ino : this is warn: log level 2
-[INFO] basic.ino : this is info: log level 3
+[ERROR] basic.ino L.26 setup : this is error: log level 1
+[WARN] basic.ino L.27 setup : this is warn: log level 2
+[INFO] basic.ino L.28 setup : this is info: log level 3
 ```
 
 ### Log Level control
@@ -59,9 +57,6 @@ By defining `DEBUGLOG_DEFAULT_LOG_LEVEL_XXXX`, you can change default log level
 ```C++
 // You can also set default log level by defining macro (default: INFO)
 #define DEBUGLOG_DEFAULT_LOG_LEVEL_TRACE
-
-// You can call other macros, functions, or define strings that will be included in all log statements
-#define LOG_PREAMBLE __FILE__ " : "
 
 // Include DebugLog after that
 #include <DebugLog.h>
@@ -87,11 +82,11 @@ LOG_TRACE("this is trace log");
 will output
 
 ```
-[ERROR] basic.ino : this is error: log level 1
-[WARN] basic.ino : this is warn: log level 2
-[INFO] basic.ino : this is info: log level 3
-[DEBUG] basic.ino : this is debug: log level 4
-[TRACE] basic.ino : this is trace: log level 5
+[ERROR] basic.ino L.26 setup : this is error: log level 1
+[WARN] basic.ino L.27 setup : this is warn: log level 2
+[INFO] basic.ino L.28 setup : this is info: log level 3
+[DEBUG] basic.ino L.29 setup : this is debug: log level 4
+[TRACE] basic.ino L.30 setup : this is trace: log level 5
 ```
 
 ### Assertion
@@ -206,9 +201,6 @@ You can disable `LOG_XXXX` and `ASSERT` macro completely by defining following m
 // You can also set default log level by defining macro (default: INFO)
 // #define DEBUGLOG_DEFAULT_LOG_LEVEL_TRACE
 
-// You can call other macros, functions, or define strings that will be included in all log statements
-#define LOG_PREAMBLE __FILE__ " : "
-
 #include <DebugLog.h>
 
 void setup() {
@@ -261,12 +253,12 @@ void setup() {
 ```
 DebugLog can print variable args: 1 2.20 three => like this
 current log level is 3
-[ERROR] basic.ino : this is error log
-[WARN] basic.ino : this is warn log
-[INFO] basic.ino : this is info log
+[ERROR] basic.ino L.26 setup : this is error log
+[WARN] basic.ino L.27 setup : this is warn log
+[INFO] basic.ino L.28 setup : this is info log
 Array can be also printed like this [1.10, 2.20, 3.30]
 Containers can also be printed like [1, 2, 3] [1.10, 2.20, 3.30] {one:1, three:3, two:2}
-[ASSERT] basic.ino : x != 1 => This always fails
+[ASSERT] basic.ino 51 setup : x != 1 => This always fails
 ```
 
 ## Output Log to both Serial and File
@@ -287,9 +279,6 @@ Containers can also be printed like [1, 2, 3] [1.10, 2.20, 3.30] {one:1, three:3
 // If you want use SPIFFS (ESP32) or other FileSystems
 // #include <SPIFFS.h>
 // #define fs SPIFFS
-
-// You can call other macros, functions, or define strings that will be included in all log statements
-#define LOG_PREAMBLE __FILE__ " : "
 
 // after that, include DebugLog.h
 #include <DebugLog.h>
@@ -365,10 +354,10 @@ void setup() {
 `Serial` Output
 
 ```
-[ERROR] log_to_file.ino : this is error log
-[WARN] log_to_file.ino : this is warn log
-[INFO] log_to_file.ino : this is info log
-[ASSERT] log_to_file.ino : x != 1 => This always fails
+[ERROR] log_to_file.ino L.97 setup : this is error log
+[WARN] log_to_file.ino L.98 setup : this is warn log
+[INFO] log_to_file.ino L.99 setup : this is info log
+[ASSERT] log_to_file.ino 122 setup : x != 1 => This always fails
 ```
 
 `File` Output
@@ -376,10 +365,10 @@ void setup() {
 ```
 DebugLog can print variable args: 1 2.20 three => like this
 current log level is 1
-[ERROR] log_to_file.ino : this is error log
+[ERROR] log_to_file.ino L.97 setup : this is error log
 Array can be also printed like this [1.10, 2.20, 3.30]
 Containers can also be printed like [1, 2, 3] [1.10, 2.20, 3.30] {one:1, three:3, two:2}
-[ASSERT] log_to_file.ino : x != 1 => This always fails
+[ASSERT] log_to_file.ino 122 setup : x != 1 => This always fails
 ```
 
 ## Control Log Level Scope

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Logging library for Arduino that can output to both Serial and File with one lin
 - Multiple file system support (`SD`, `SdFat`, `SPIFFS`, etc.)
 - Support array and container (`std::vector`, `std::deque`, `std::map`) output
 - APIs can also be used in standard C++ apps
+- Custom preamble support `#define LOG_PREAMBLE` can easily call functions and other macros for every `LOG_XXXXX` call
 
 ## Basic Usage
 
@@ -32,6 +33,7 @@ Logging library for Arduino that can output to both Serial and File with one lin
 `LOG_XXXX` output is controlled by log level. Default log level is `DebugLogLevel::LVL_INFO`
 
 ```C++
+#define LOG_PREAMBLE __FILE__ " : "
 #include <DebugLog.h>
 
 // The default log_leval is DebugLogLevel::LVL_INFO
@@ -45,9 +47,9 @@ LOG_TRACE("this is trace: log level", 5);  // won't be printed
 `Serial` output example
 
 ```
-[ERROR] basic.ino L.26 setup : this is error: log level 1
-[WARN] basic.ino L.27 setup : this is warn: log level 2
-[INFO] basic.ino L.28 setup : this is info: log level 3
+[ERROR] basic.ino : this is error: log level 1
+[WARN] basic.ino : this is warn: log level 2
+[INFO] basic.ino : this is info: log level 3
 ```
 
 ### Log Level control
@@ -57,6 +59,9 @@ By defining `DEBUGLOG_DEFAULT_LOG_LEVEL_XXXX`, you can change default log level
 ```C++
 // You can also set default log level by defining macro (default: INFO)
 #define DEBUGLOG_DEFAULT_LOG_LEVEL_TRACE
+
+// You can call other macros, functions, or define strings that will be included in all log statements
+#define LOG_PREAMBLE __FILE__ " : "
 
 // Include DebugLog after that
 #include <DebugLog.h>
@@ -82,11 +87,11 @@ LOG_TRACE("this is trace log");
 will output
 
 ```
-[ERROR] basic.ino L.26 setup : this is error: log level 1
-[WARN] basic.ino L.27 setup : this is warn: log level 2
-[INFO] basic.ino L.28 setup : this is info: log level 3
-[DEBUG] basic.ino L.29 setup : this is debug: log level 4
-[TRACE] basic.ino L.30 setup : this is trace: log level 5
+[ERROR] basic.ino : this is error: log level 1
+[WARN] basic.ino : this is warn: log level 2
+[INFO] basic.ino : this is info: log level 3
+[DEBUG] basic.ino : this is debug: log level 4
+[TRACE] basic.ino : this is trace: log level 5
 ```
 
 ### Assertion
@@ -201,6 +206,9 @@ You can disable `LOG_XXXX` and `ASSERT` macro completely by defining following m
 // You can also set default log level by defining macro (default: INFO)
 // #define DEBUGLOG_DEFAULT_LOG_LEVEL_TRACE
 
+// You can call other macros, functions, or define strings that will be included in all log statements
+#define LOG_PREAMBLE __FILE__ " : "
+
 #include <DebugLog.h>
 
 void setup() {
@@ -253,12 +261,12 @@ void setup() {
 ```
 DebugLog can print variable args: 1 2.20 three => like this
 current log level is 3
-[ERROR] basic.ino L.26 setup : this is error log
-[WARN] basic.ino L.27 setup : this is warn log
-[INFO] basic.ino L.28 setup : this is info log
+[ERROR] basic.ino : this is error log
+[WARN] basic.ino : this is warn log
+[INFO] basic.ino : this is info log
 Array can be also printed like this [1.10, 2.20, 3.30]
 Containers can also be printed like [1, 2, 3] [1.10, 2.20, 3.30] {one:1, three:3, two:2}
-[ASSERT] basic.ino 51 setup : x != 1 => This always fails
+[ASSERT] basic.ino : x != 1 => This always fails
 ```
 
 ## Output Log to both Serial and File
@@ -279,6 +287,9 @@ Containers can also be printed like [1, 2, 3] [1.10, 2.20, 3.30] {one:1, three:3
 // If you want use SPIFFS (ESP32) or other FileSystems
 // #include <SPIFFS.h>
 // #define fs SPIFFS
+
+// You can call other macros, functions, or define strings that will be included in all log statements
+#define LOG_PREAMBLE __FILE__ " : "
 
 // after that, include DebugLog.h
 #include <DebugLog.h>
@@ -354,10 +365,10 @@ void setup() {
 `Serial` Output
 
 ```
-[ERROR] log_to_file.ino L.97 setup : this is error log
-[WARN] log_to_file.ino L.98 setup : this is warn log
-[INFO] log_to_file.ino L.99 setup : this is info log
-[ASSERT] log_to_file.ino 122 setup : x != 1 => This always fails
+[ERROR] log_to_file.ino : this is error log
+[WARN] log_to_file.ino : this is warn log
+[INFO] log_to_file.ino : this is info log
+[ASSERT] log_to_file.ino : x != 1 => This always fails
 ```
 
 `File` Output
@@ -365,10 +376,10 @@ void setup() {
 ```
 DebugLog can print variable args: 1 2.20 three => like this
 current log level is 1
-[ERROR] log_to_file.ino L.97 setup : this is error log
+[ERROR] log_to_file.ino : this is error log
 Array can be also printed like this [1.10, 2.20, 3.30]
 Containers can also be printed like [1, 2, 3] [1.10, 2.20, 3.30] {one:1, three:3, two:2}
-[ASSERT] log_to_file.ino 122 setup : x != 1 => This always fails
+[ASSERT] log_to_file.ino : x != 1 => This always fails
 ```
 
 ## Control Log Level Scope

--- a/examples/options/options.ino
+++ b/examples/options/options.ino
@@ -38,11 +38,6 @@ void setup() {
     LOG_SET_DELIMITER(" and ");
     PRINTLN("Changed delimtier from \" \" to \" and \"");
     LOG_INFO(1, 2, 3, 4, 5);
-
-    // You can change some log format options
-    LOG_SET_OPTION(false, false, false);  // disable file, line, func
-    PRINTLN("Disabled file, line, and func from log output format");
-    LOG_INFO("You can't see file, line, and func here");
 }
 
 void loop() {


### PR DESCRIPTION
This should address Issue #8 which is the feature request for "Cutsom log format - add timestamp"

# What I changed
```C
// Before the log macros looked like this
#define LOG_ERROR(...) DebugLog::Manager::get().log(arx::debug::LogLevel::LVL_ERROR, LOG_SHORT_FILENAME, __LINE__, __func__, __VA_ARGS__)

// Now it looks like this
#define LOG_ERROR(...) DebugLog::Manager::get().log(arx::debug::LogLevel::LVL_ERROR, LOG_SHORT_FILENAME, LOG_PREAMBLE, __VA_ARGS__)
```

# How to use it
Before you `#include <DebugLog.h>` simply define a LOG_PREAMBLE macro.
```C
#define LOG_PREAMBLE __LINE__, __func__, "This string will go before all log statements: "
#include <DebugLog.h>
```
