### PR TITLE
fix: disable DebugLogPrecision on non-Arduino environment

### DIFF
--- a/DebugLog.h
+++ b/DebugLog.h
@@ -19,7 +19,9 @@
 namespace DebugLog = arx::debug;
 using DebugLogLevel = arx::debug::LogLevel;
 using DebugLogBase = arx::debug::LogBase;
+#ifdef ARDUINO
 using DebugLogPrecision = arx::debug::LogPrecision;
+#endif
 
 // PRINT and PRINTLN are always enabled regardless of log_level
 // PRINT and PRINTLN do NOT print to files


### PR DESCRIPTION
Fix https://github.com/hideakitai/DebugLog/issues/14