### PR TITLE
feat: optionally set a different default Arduino stream

### DIFF
--- a/DebugLog/Manager.h
+++ b/DebugLog/Manager.h
@@ -15,7 +15,7 @@ namespace debug {
         bool b_base_reset {true};
 
 #ifdef ARDUINO
-        Stream* stream {&Serial};
+        Stream* stream {&DEBUGLOG_DEFAULT_ARDUINO_STREAM};
         FileLogger* logger {nullptr};
         LogLevel file_lvl {DEBUGLOG_DEFAULT_FILE_LEVEL};
         bool b_auto_save {false};

--- a/DebugLog/Types.h
+++ b/DebugLog/Types.h
@@ -132,4 +132,8 @@ namespace debug {
 #define DEBUGLOG_DEFAULT_FILE_LEVEL LogLevel::LVL_ERROR
 #endif
 
+#ifndef DEBUGLOG_DEFAULT_ARDUINO_STREAM
+#define DEBUGLOG_DEFAULT_ARDUINO_STREAM Serial
+#endif
+
 #endif  // DEBUGLOG_TYPES_H

--- a/README.md
+++ b/README.md
@@ -115,6 +115,13 @@ LOG_ATTACH_STREAM(your_tcp_client);
 LOG_ATTACH_STREAM(any_other_stream);
 ```
 
+The default can be changed by defining `DEBUGLOG_DEFAULT_ARDUINO_STREAM` before including `DebugLog.h`:
+
+```cpp
+#define DEBUGLOG_DEFAULT_ARDUINO_STREAM Serial2
+#include <DebugLog.h>
+```
+
 ### Log Preamble Control
 
 The `LOG_PREAMBLE` macro is called every `LOG_XXXX`. It defines a string that will be printed between the `[LEVEL]` and your custom message. To override the default definition, you must define the macro **before** you `#include <DebugLog.h>`


### PR DESCRIPTION
To support the Arduino UNO Q use cases, it is important to avoid accessing the `Serial` object from this library. 

This PR allows the user to set the default stream to something else, such as `Serial1` or `Serial2`, by defining `DEBUGLOG_DEFAULT_ARDUINO_STREAM` before including the library. This change is backward compatible, as the default will still be `Serial` if the macro is not defined.